### PR TITLE
Ajuste de constante COMMANDS

### DIFF
--- a/lib/pki_express/commands.rb
+++ b/lib/pki_express/commands.rb
@@ -1,25 +1,27 @@
+# frozen_string_literal: true
+
 module PkiExpress
   class Commands
-    SIGN_CADES = 'sign-cades',
-    SIGN_PADES = 'sign-pades',
-    SIGN_XML = 'sign-xml',
-    START_CADES = 'start-cades',
-    START_PADES = 'start-pades',
-    START_XML = 'start-xml',
-    COMPLETE_SIG = 'complete-sig',
-    OPEN_PADES = 'open-pades',
-    OPEN_CADES = 'open-cades',
-    EDIT_PDF = 'edit-pdf',
-    MERGE_CMS = 'merge-cms',
-    START_AUTH = 'start-auth',
-    COMPLETE_AUTH = 'complete-auth',
-    STAMP_PDF = 'stamp-pdf',
-    READ_CERT = 'read-cert',
-    GEN_KEY = 'gen-key',
-    CREATE_PFX = 'create-pfx',
-    CHECK_SERVICE = 'check-service',
-    DISCOVER_SERVICES = 'discover-services',
-    PASSWORD_AUTHORIZE = 'pwd-auth',
+    SIGN_CADES = 'sign-cades'
+    SIGN_PADES = 'sign-pades'
+    SIGN_XML = 'sign-xml'
+    START_CADES = 'start-cades'
+    START_PADES = 'start-pades'
+    START_XML = 'start-xml'
+    COMPLETE_SIG = 'complete-sig'
+    OPEN_PADES = 'open-pades'
+    OPEN_CADES = 'open-cades'
+    EDIT_PDF = 'edit-pdf'
+    MERGE_CMS = 'merge-cms'
+    START_AUTH = 'start-auth'
+    COMPLETE_AUTH = 'complete-auth'
+    STAMP_PDF = 'stamp-pdf'
+    READ_CERT = 'read-cert'
+    GEN_KEY = 'gen-key'
+    CREATE_PFX = 'create-pfx'
+    CHECK_SERVICE = 'check-service'
+    DISCOVER_SERVICES = 'discover-services'
+    PASSWORD_AUTHORIZE = 'pwd-auth'
     COMPLETE_SERVICE_AUTH = 'complete-service-auth'
   end
 end


### PR DESCRIPTION
Atualmente `PkiExpress::Commands::SIGN_CADES` está apontando para todas as referências de comandos: 

```
PkiExpress::Commands::SIGN_CADES
=> 
["sign-cades",
 "sign-pades",
 "sign-xml",
 "start-cades",
 "start-pades",
 "start-xml",
 "complete-sig",
 "open-pades",
 ...```